### PR TITLE
Add informative descriptions of condition results

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/codesonar/CodeSonarPublisher.java
+++ b/src/main/java/org/jenkinsci/plugins/codesonar/CodeSonarPublisher.java
@@ -274,7 +274,7 @@ public class CodeSonarPublisher extends Recorder implements SimpleBuildStep {
 
         for (Condition condition : conditions) {
             Result validationResult = condition.validate(buildActionDTO, compareDTO, launcher, listener);
-            Pair<String, String> pair = Pair.with(condition.getDescriptor().getDisplayName(), validationResult.toString());
+            Pair<String, String> pair = Pair.with(condition.describeResult(), validationResult.toString());
             conditionNamesAndResults.add(pair);
             run.setResult(validationResult);
             listener.getLogger().println(String.format("[CodeSonar] '%s' marked the build as %s", condition.getDescriptor().getDisplayName(), validationResult.toString()));

--- a/src/main/java/org/jenkinsci/plugins/codesonar/conditions/Condition.java
+++ b/src/main/java/org/jenkinsci/plugins/codesonar/conditions/Condition.java
@@ -40,4 +40,8 @@ public abstract class Condition implements Describable<Condition>, ExtensionPoin
 
         throw new NullPointerException("Jenkins is not started or is stopped");
     }
+
+    public String describeResult() {
+        return getDescriptor().getDisplayName();
+    }
 }

--- a/src/main/java/org/jenkinsci/plugins/codesonar/conditions/NewWarningsIncreasedByPercentageCondition.java
+++ b/src/main/java/org/jenkinsci/plugins/codesonar/conditions/NewWarningsIncreasedByPercentageCondition.java
@@ -22,6 +22,7 @@ public class NewWarningsIncreasedByPercentageCondition extends Condition {
     private static final String NAME = "Warning count increase: new only";
     private String percentage = "5.0f";
     private String warrantedResult = Result.UNSTABLE.toString();
+    private String resultDescription = NAME;
     
     @DataBoundConstructor
     public NewWarningsIncreasedByPercentageCondition(String percentage) {
@@ -60,16 +61,24 @@ public class NewWarningsIncreasedByPercentageCondition extends Condition {
         Analysis currentActiveWarnings = current.getAnalysisActiveWarnings();
         Analysis currentNewWarnings = current.getAnalysisNewWarnings();
 
-        float activeWarningCount = (float) currentActiveWarnings.getWarnings().size();
-        float newWarningCount = (float) currentNewWarnings.getWarnings().size();
+        int activeWarningCount = currentActiveWarnings.getWarnings().size();
+        int newWarningCount = currentNewWarnings.getWarnings().size();
 
         float result = (newWarningCount * 100.0f) / activeWarningCount; 
+        float thresholdPercentage = Float.parseFloat(percentage);
 
-        if (result > Float.parseFloat(percentage)) {
+        if (result > thresholdPercentage) {
+            resultDescription = String.format("More than %.2f%% new warnings (%.2f%%, %d out of %d)", thresholdPercentage, result, newWarningCount, activeWarningCount);
             return Result.fromString(warrantedResult);
         }
 
+        resultDescription = String.format("At most %.2f%% new warnings (%.2f%%, %d out of %d)", thresholdPercentage, result, newWarningCount, activeWarningCount);
         return Result.SUCCESS;
+    }
+
+    @Override
+    public String describeResult() {
+        return resultDescription;
     }
 
     @Symbol("warningCountIncreaseNewOnly")

--- a/src/main/java/org/jenkinsci/plugins/codesonar/conditions/ProcedureCyclomaticComplexityExceededCondition.java
+++ b/src/main/java/org/jenkinsci/plugins/codesonar/conditions/ProcedureCyclomaticComplexityExceededCondition.java
@@ -29,6 +29,7 @@ public class ProcedureCyclomaticComplexityExceededCondition extends Condition {
 
     private int maxCyclomaticComplexity = 30;
     private String warrantedResult = Result.UNSTABLE.toString();
+    private String resultDescription = NAME;
 
     @DataBoundConstructor
     public ProcedureCyclomaticComplexityExceededCondition(int maxCyclomaticComplexity) {
@@ -63,12 +64,19 @@ public class ProcedureCyclomaticComplexityExceededCondition extends Condition {
         for (ProcedureRow procedureRow : procedureRows) {
             Metric cyclomaticComplexityMetric = procedureRow.getMetricByName("Cyclomatic Complexity");
 
-            String value = cyclomaticComplexityMetric.getValue();
-            if (Integer.parseInt(value) > maxCyclomaticComplexity) {
+            int value = Integer.parseInt(cyclomaticComplexityMetric.getValue());
+            if (value > maxCyclomaticComplexity) {
+                resultDescription = String.format("Cyclomatic complexity %d of procedure %s exceeded limit %d", value, procedureRow.getProcedure(), maxCyclomaticComplexity);
                 return Result.fromString(warrantedResult);
             }
         }
+        resultDescription = String.format("Cyclomatic complexity is at most %d", maxCyclomaticComplexity);
         return Result.SUCCESS;
+    }
+
+    @Override
+    public String describeResult() {
+        return resultDescription;
     }
     
     @Symbol("cyclomaticComplexity")

--- a/src/main/java/org/jenkinsci/plugins/codesonar/conditions/RedAlertLimitCondition.java
+++ b/src/main/java/org/jenkinsci/plugins/codesonar/conditions/RedAlertLimitCondition.java
@@ -28,6 +28,7 @@ public class RedAlertLimitCondition extends Condition {
 
     private int alertLimit = 1;
     private String warrantedResult = Result.UNSTABLE.toString();
+    private String resultDescription = NAME;
 
     @DataBoundConstructor
     public RedAlertLimitCondition(int alertLimit) {
@@ -60,10 +61,17 @@ public class RedAlertLimitCondition extends Condition {
 
         List<Alert> redAlerts = current.getAnalysisActiveWarnings().getRedAlerts();
         if (redAlerts.size() > alertLimit) {
+            resultDescription = String.format("More than %d red alerts (%d)", alertLimit, redAlerts.size());
             return Result.fromString(warrantedResult);
         }
 
+        resultDescription = String.format("At most %d red alerts (%d)", alertLimit, redAlerts.size());
         return Result.SUCCESS;
+    }
+
+    @Override
+    public String describeResult() {
+        return resultDescription;
     }
 
     @Symbol("redAlerts")

--- a/src/main/java/org/jenkinsci/plugins/codesonar/conditions/WarningCountAbsoluteSpecifiedScoreAndHigherCondition.java
+++ b/src/main/java/org/jenkinsci/plugins/codesonar/conditions/WarningCountAbsoluteSpecifiedScoreAndHigherCondition.java
@@ -30,6 +30,7 @@ public class WarningCountAbsoluteSpecifiedScoreAndHigherCondition extends Condit
     private int rankOfWarnings = 30;
     private int warningCountThreshold = 20;
     private String warrantedResult = Result.UNSTABLE.toString();
+    private String resultDescription = NAME;
 
     @DataBoundConstructor
     public WarningCountAbsoluteSpecifiedScoreAndHigherCondition(int rankOfWarnings, int warningCountThreshold) {
@@ -80,10 +81,17 @@ public class WarningCountAbsoluteSpecifiedScoreAndHigherCondition extends Condit
         }
 
         if (severeWarnings > warningCountThreshold) {
+            resultDescription = String.format("More than %d warnings with a score of at least %d (%d)", warningCountThreshold, rankOfWarnings, severeWarnings);
             return Result.fromString(warrantedResult);
         }
 
+        resultDescription = String.format("At most %d warnings with a score of at least %d (%d)", warningCountThreshold, rankOfWarnings, severeWarnings);
         return Result.SUCCESS;
+    }
+
+    @Override
+    public String describeResult() {
+        return resultDescription;
     }
 
     @Symbol("warningCountAbsoluteSpecifiedScoreAndHigher")

--- a/src/main/java/org/jenkinsci/plugins/codesonar/conditions/WarningCountIncreaseOverallCondition.java
+++ b/src/main/java/org/jenkinsci/plugins/codesonar/conditions/WarningCountIncreaseOverallCondition.java
@@ -22,6 +22,7 @@ public class WarningCountIncreaseOverallCondition extends Condition {
     private static final String NAME = "Warning count increase: overall";
     private String percentage = String.valueOf(5.0f);
     private String warrantedResult = Result.UNSTABLE.toString();
+    private String resultDescription = NAME;
 
     @DataBoundConstructor
     public WarningCountIncreaseOverallCondition(String percentage) {
@@ -61,15 +62,24 @@ public class WarningCountIncreaseOverallCondition extends Condition {
             return Result.SUCCESS;
         }
 
-        float previousCount = (float) previous.getAnalysisActiveWarnings().getWarnings().size();
-        float currentCount = (float) current.getAnalysisActiveWarnings().getWarnings().size();
-        float diff = currentCount - previousCount;
+        int previousCount = previous.getAnalysisActiveWarnings().getWarnings().size();
+        int currentCount = current.getAnalysisActiveWarnings().getWarnings().size();
+        int diff = currentCount - previousCount;
+        float thresholdPercentage = Float.parseFloat(percentage);
+        float result = (((float) diff) / previousCount) * 100;
 
-        if ((diff / previousCount) * 100 > Float.parseFloat(percentage)) {
+        if (result > thresholdPercentage) {
+            resultDescription = String.format("More than %.2f%% increase in warnings (%.2f%%, %d out of %d)", thresholdPercentage, result, diff, previousCount);
             return Result.fromString(warrantedResult);
         }
 
+        resultDescription = String.format("At most %.2f%% increase in warnings (%.2f%%, %d out of %d)", thresholdPercentage, result, diff, previousCount);
         return Result.SUCCESS;
+    }
+
+    @Override
+    public String describeResult() {
+        return resultDescription;
     }
 
     @Symbol("warningCountIncreaseOverall")

--- a/src/main/java/org/jenkinsci/plugins/codesonar/conditions/WarningCountIncreaseSpecifiedScoreAndHigherCondition.java
+++ b/src/main/java/org/jenkinsci/plugins/codesonar/conditions/WarningCountIncreaseSpecifiedScoreAndHigherCondition.java
@@ -31,6 +31,7 @@ public class WarningCountIncreaseSpecifiedScoreAndHigherCondition extends Condit
     private int rankOfWarnings = 30;
     private String warningPercentage = String.valueOf(5.0f);
     private String warrantedResult = Result.UNSTABLE.toString();
+    private String resultDescription = NAME;
 
     @DataBoundConstructor
     public WarningCountIncreaseSpecifiedScoreAndHigherCondition(int rankOfWarnings, String warningPercentage) {
@@ -82,12 +83,20 @@ public class WarningCountIncreaseSpecifiedScoreAndHigherCondition extends Condit
         }
 
         float calculatedWarningPercentage = (severeWarnings / totalNumberOfWarnings) * 100;
+        float thresholdPercentage = Float.parseFloat(warningPercentage);
 
-        if (calculatedWarningPercentage > Float.parseFloat(warningPercentage)) {
+        if (calculatedWarningPercentage > thresholdPercentage) {
+            resultDescription = String.format("More than %.2f%% warnings with score more than %d (%.2f%%, %d out of %d)", thresholdPercentage, rankOfWarnings, result, severeWarnings, totalNumberOfWarnings);
             return Result.fromString(warrantedResult);
         }
 
+        resultDescription = String.format("At most %.2f%% warnings with score more than %d (%.2f%%, %d out of %d)", thresholdPercentage, rankOfWarnings, result, severeWarnings, totalNumberOfWarnings);
         return Result.SUCCESS;
+    }
+
+    @Override
+    public String describeResult() {
+        return resultDescription;
     }
 
     @Symbol("warningCountIncreaseSpecifiedScoreAndHigher")

--- a/src/main/java/org/jenkinsci/plugins/codesonar/conditions/YellowAlertLimitCondition.java
+++ b/src/main/java/org/jenkinsci/plugins/codesonar/conditions/YellowAlertLimitCondition.java
@@ -27,6 +27,7 @@ public class YellowAlertLimitCondition extends Condition {
    
     private int alertLimit = 1;
     private String warrantedResult = Result.UNSTABLE.toString();
+    private String resultDescription = NAME;
 
     @DataBoundConstructor
     public YellowAlertLimitCondition(int alertLimit) {
@@ -59,10 +60,17 @@ public class YellowAlertLimitCondition extends Condition {
         
         List<Alert> yellowAlerts = current.getAnalysisActiveWarnings().getYellowAlerts();
         if (yellowAlerts.size() > alertLimit) {
+            resultDescription = String.format("More than %d yellow alerts (%d)", alertLimit, yellowAlerts.size());
             return Result.fromString(warrantedResult);
         }
 
+        resultDescription = String.format("At most %d yellow alerts (%d)", alertLimit, yellowAlerts.size());
         return Result.SUCCESS;
+    }
+
+    @Override
+    public String describeResult() {
+        return resultDescription;
     }
 
     @Symbol("yellowAlerts")


### PR DESCRIPTION
Whether a condition fails or passes, it is of interest to the user why it did so. Since we have the information, we might as well present it.

This also helps when several instances of the same condition class are used in the same job.

Note: I have not been able to test this. It seems the tests are mostly manual?