### PR TITLE
Proposed README updates to describe projectFile, etc. parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -580,9 +580,9 @@ cyclomaticComplexity(maxCyclomaticComplexity:'8', warrantedResult:'UNSTABLE'),
 
 ### Note on visibility filters
 
-The CodeSonar warning *visibility filter* allows you to specify exactly which warnings you are interested in: for example, you might be interested in all warnings, or only in active warnings (that is, those that are not marked as "suppressed", "fixed", "invalid", etc.).  Defaults to "active".
+The CodeSonar warning *visibility filter* allows you to specify exactly which warnings you are interested in: for example, you might be interested in all warnings, or only in active warnings.  Defaults to "active".  With factory settings, the "active" filter includes only warnings that are not marked as "suppressed", "fixed", "invalid", etc.
 
-The CodeSonar *new warnings filter* allows you to specify exactly what warnings will be considered new.  By default, the plugin will attempt to use the filter named "new".  With CodeSonar factory settings, the "new" filter includes only warnings that were issued for the first time in the current analysis.
+The CodeSonar *new warnings filter* allows you to specify exactly what warnings will be considered new.  Defaults to "new".  With CodeSonar factory settings, the "new" filter includes only warnings that were issued for the first time in the current analysis.
 
 * You can specify a warning visibility filter by *name* or by numeric *ID*.
 * The available warning visibility filters for a given hub user account are those for which the account has `NAMEDSEARCH_READ` permission. The exception is the **all** filter, which is always available to all users.

--- a/README.md
+++ b/README.md
@@ -342,18 +342,10 @@ analysis information from the hub.
       ```
       socketTimeoutMS: 300000,
       ```
-    * To specify a CodeSonar analysis ID of `<X>` which the CodeSonar plugin should use for evaluating analysis results, replace the `projectFile` line with the following.
-      ```
-      aid: <X>,
-      ```
-      For example, to specify an analysis ID of 81:
-      ```
-      aid: 81,
-      ```
-    * To specify a custom warning filter <X> for identifying new warnings, edit the last lines of the `codesonar` plugin invocation as follows.
+    * To specify a custom warning filter `<F>` for identifying new warnings, edit the last lines of the `codesonar` plugin invocation as follows.
       ```
       visibilityFilter: "active",
-      newWarningsFilter: <X>)
+      newWarningsFilter: <F>)
       ```
       For example, to specify a saved search named "new":
       ```
@@ -361,6 +353,16 @@ analysis information from the hub.
       newWarningsFilter: "new")
       ```
       See the [note on visibility filters](#note-on-visibility-filters) below.
+    * To evaluate the results of a different analysis on our hub, replace the `projectFile` line with the following, where `<AID>` is the relevant *analysis id*.
+      ```
+      aid: <AID>,
+      ```
+      For example, to evaluate the results of the analysis whose ID is 81:
+      ```
+      aid: 81,
+      ```
+      In most cases the `projectFile` is the best way to identify the analysis of interest.
+      However, you might want to use a different analysis in a more complex configuration involving multiple analyses.
 
 1. Click **Save**.
 1. Check that everything is working properly.
@@ -580,7 +582,7 @@ cyclomaticComplexity(maxCyclomaticComplexity:'8', warrantedResult:'UNSTABLE'),
 
 The CodeSonar warning *visibility filter* allows you to specify exactly which warnings you are interested in: for example, you might be interested in all warnings, or only in active warnings (that is, those that are not marked as "suppressed", "fixed", "invalid", etc.).
 
-The CodeSonar *new warnings filter* allows you to specify exactly what warnings will be considered new.  By default, the plugin will attempt to use the filter named "new", which is initially defined to include only warnings that were issued for the first time in the current analysis.
+The CodeSonar *new warnings filter* allows you to specify exactly what warnings will be considered new.  By default, the plugin will attempt to use the filter named "new".  With CodeSonar factory settings, the "new" filter includes only warnings that were issued for the first time in the current analysis.
 
 * You can specify a warning visibility filter by *name* or by numeric *ID*.
 * The available warning visibility filters for a given hub user account are those for which the account has `NAMEDSEARCH_READ` permission. The exception is the **all** filter, which is always available to all users.

--- a/README.md
+++ b/README.md
@@ -309,15 +309,12 @@ analysis information from the hub.
 1. Add the following step to your Pipeline after all your build steps.
    ```
    script {
-        def analysisId = sh(
-            script: 'cat "$CSONAR_WORKDIR/$CSONAR_PROJECT_NAME.prj_files/aid.txt"',
-            returnStdout: true).trim()
         codesonar(
             conditions: [],
             credentialId: params.CSONAR_HUBUSERPASS,
             hubAddress: params.CSONAR_HUB_ADDRESS,
             projectName: params.CSONAR_PROJECT_NAME,
-            aid: analysisId,
+            projectFile: "${env.CSONAR_WORKDIR}/${params.CSONAR_PROJECT_NAME}",
             protocol: "http",
             visibilityFilter: "active")
     }
@@ -345,6 +342,25 @@ analysis information from the hub.
       ```
       socketTimeoutMS: 300000,
       ```
+    * To specify a CodeSonar analysis ID of `<X>` which the CodeSonar plugin should use for evaluating analysis results, replace the `projectFile` line with the following.
+      ```
+      aid: <X>,
+      ```
+      For example, to specify an analysis ID of 81:
+      ```
+      aid: 81,
+      ```
+    * To specify a custom warning filter <X> for identifying new warnings, edit the last lines of the `codesonar` plugin invocation as follows.
+      ```
+      visibilityFilter: "active",
+      newWarningsFilter: <X>)
+      ```
+      For example, to specify a saved search named "new":
+      ```
+      visibilityFilter: "active",
+      newWarningsFilter: "new")
+      ```
+      See the [note on visibility filters](#note-on-visibility-filters) below.
 
 1. Click **Save**.
 1. Check that everything is working properly.
@@ -562,7 +578,9 @@ cyclomaticComplexity(maxCyclomaticComplexity:'8', warrantedResult:'UNSTABLE'),
 
 ### Note on visibility filters
 
-The CodeSonar warning visibility filter allows you to specify exactly which warnings you are interested in: for example, you might be interested in all warnings, or only in new warnings (that is, those that were issued for the first time in the current analysis). 
+The CodeSonar warning *visibility filter* allows you to specify exactly which warnings you are interested in: for example, you might be interested in all warnings, or only in active warnings (that is, those that are not marked as "suppressed", "fixed", "invalid", etc.).
+
+The CodeSonar *new warnings filter* allows you to specify exactly what warnings will be considered new.  By default, the plugin will attempt to use the filter named "new", which is initially defined to include only warnings that were issued for the first time in the current analysis.
 
 * You can specify a warning visibility filter by *name* or by numeric *ID*.
 * The available warning visibility filters for a given hub user account are those for which the account has `NAMEDSEARCH_READ` permission. The exception is the **all** filter, which is always available to all users.

--- a/README.md
+++ b/README.md
@@ -580,7 +580,7 @@ cyclomaticComplexity(maxCyclomaticComplexity:'8', warrantedResult:'UNSTABLE'),
 
 ### Note on visibility filters
 
-The CodeSonar warning *visibility filter* allows you to specify exactly which warnings you are interested in: for example, you might be interested in all warnings, or only in active warnings (that is, those that are not marked as "suppressed", "fixed", "invalid", etc.).
+The CodeSonar warning *visibility filter* allows you to specify exactly which warnings you are interested in: for example, you might be interested in all warnings, or only in active warnings (that is, those that are not marked as "suppressed", "fixed", "invalid", etc.).  Defaults to "active".
 
 The CodeSonar *new warnings filter* allows you to specify exactly what warnings will be considered new.  By default, the plugin will attempt to use the filter named "new".  With CodeSonar factory settings, the "new" filter includes only warnings that were issued for the first time in the current analysis.
 


### PR DESCRIPTION
Updates the README to explain new parameters:

* `projectFile` - the CodeSonar project file
* `newWarningsFilter` - warning filter used for finding new warnings

Note that we no longer need to include any tricks for extracting the Analysis ID from the prj_files since the plugin will find the Analysis ID by looking in the `projectFile`.