### PR TITLE
Update some dependency libraries

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -117,7 +117,7 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>job-dsl</artifactId>
-            <version>1.37</version>
+            <version>1.72</version>
             <optional>true</optional>
             <exclusions>
                 <exclusion>


### PR DESCRIPTION
Update job-dsl plugin to address critical security vulnerability [CVE-2019-1003034](https://nvd.nist.gov/vuln/detail/CVE-2019-1003034).